### PR TITLE
build.sh: Fix path issues for ms.py, stopword.py

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ cc vc/bow.c vc/vcutils.c -Wall -o $DIR/vc/bow
 cp utils/mknbcdat.sh $DIR/utils/mknbcdat.sh
 cp utils/ms.py $DIR/utils/ms.py
 cp utils/config.py $DIR/utils/config.py
-cp utils/stopword.py $DIR/stopword.py
+cp utils/stopword.py $DIR/utils/stopword.py
 
 chmod +x $DIR/utils/mknbcdat.sh
-chmod +x $DIR/ms.py
+chmod +x $DIR/utils/ms.py


### PR DESCRIPTION
There are problems not reviewing script changes carefully.