### PR TITLE
Initialize pointers to NULL before calling getline() + Better exception logging

### DIFF
--- a/src/glue.py
+++ b/src/glue.py
@@ -4,6 +4,7 @@
 import sys
 import time
 import json
+import traceback
 import websocket
 
 from verinfo import ver_info
@@ -154,15 +155,16 @@ def ms_ws_listener():
                 ml.exec_ml(post_id, post_tuple, is_over_thres)
         except RuntimeError as e:
             # Severe errors
-            msg.output("{}".format(e), msg.ERROR, tags=["Framework"])
-            raise
+            msg.output("{}: {}".format(type(e).__name__, e), msg.ERROR, tags=["Framework"])
+            raise  # No need to print traceback as it is raised again
         except KeyboardInterrupt:
             msg.output("User enforced program termination.",
                        msg.DEBUG, tags=["Framework"])
             ws.close()
             return None
         except Exception as e:
-            msg.output("{}".format(e), msg.WARNING, tags=["Framework"])
+            msg.output("{}: {}".format(type(e).__name__, e), msg.WARNING, tags=["Framework"])
+            msg.output(traceback.format_exc(), msg.VERBOSE, tags=["Framework", "Traceback"])
             # Reconnect.
             try:
                 ws.close()

--- a/src/vc/bow.c
+++ b/src/vc/bow.c
@@ -11,7 +11,7 @@ int main(){
      * Output format:
      * Output consists many lines, with one hash on each line. Each hash is represented by a base 10 integer.
      * The number of lines in the output is the same as that of input. An EOF signal will be sent when output ends. */
-    unsigned char *phrase;
+    unsigned char *phrase = NULL;
     size_t size_phrase = 0;
     ssize_t len_phrase;
     uint32_t hash_result;

--- a/src/vc/ngram.c
+++ b/src/vc/ngram.c
@@ -21,7 +21,7 @@ int main(){
      * Output consists many lines, with one hash on each line. Each hash is represented by a base 10 integer.
      * The number of lines in the output is 4 lines less than that of input. If input is less that 5 lines
      * but greater than 0 line, output is 1 line. An EOF signal will be sent when output ends. */
-    unsigned char *phrase;
+    unsigned char *phrase = NULL;
     size_t size_phrase = 0;
     ssize_t len_phrase;
 

--- a/src/vc/osb.c
+++ b/src/vc/osb.c
@@ -21,7 +21,7 @@ int main(){
      * Output consists many lines, with one hash on each line. Each hasah is represented by a base 10 interger.
      * For first four lines of input, there will be i - 1 output lines for i-th input line.
      * For later lines, there will be 4 output lines for each input line. */
-    unsigned char *phrase;
+    unsigned char *phrase = NULL;
     size_t size_phrase = 0;
     ssize_t len_phrase;
     uint32_t hash_r[PHRASE_PER_GROUP] = {0};

--- a/src/vc/sbph.c
+++ b/src/vc/sbph.c
@@ -47,7 +47,7 @@ int main(){
      * Output consists many lines, with one hash on each line. Each hash is represented by a base 10 integer.
      * For first four lines of input, there will be 2 ^ (i - 1) output lines for i-th input line.
      * For later lines, there will be 16 output lines for each input line. */
-    unsigned char *phrase;
+    unsigned char *phrase = NULL;
     size_t size_phrase = 0;
     ssize_t len_phrase;
     uint32_t hash_r[PHRASE_PER_GROUP] = {0};


### PR DESCRIPTION
Fixes the segmentation fault issue.
Print traceback as a part of exception logging.
