### PR TITLE
nbc.c: Show the log-2 posterior ratio too

### DIFF
--- a/src/cf/nbc.c
+++ b/src/cf/nbc.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[]){
     else{
         data_file = fopen(&(argv[2][7]), "rb");
         log_posterior_ratio = bayes_classify(data_file);
-        printf("%c (%lf)\n", ((log_posterior_ratio > 0) ? 'T' : 'F'), log_posterior_ratio);
+        printf("%c (%Lf)\n", ((log_posterior_ratio > 0) ? 'T' : 'F'), log_posterior_ratio);
     }
 
     fclose(data_file);


### PR DESCRIPTION
The output of ratio is removed when moving onto a new glueware architecture. However, it can be beneficial to add it back, as the ratio provides the information of how confident the classifier is regarding if a post is spam/non-spam.